### PR TITLE
Send credentials when making requests for imported modules in noVNC

### DIFF
--- a/jupyter_desktop/share/web/noVNC-1.1.0/vnc_lite.html
+++ b/jupyter_desktop/share/web/noVNC-1.1.0/vnc_lite.html
@@ -77,7 +77,7 @@
     </script>
 
     <!-- actual script modules -->
-    <script type="module" crossorigin="anonymous">
+    <script type="module" crossorigin="use-credentials">
         // RFB holds the API to connect and communicate with a VNC server
         import RFB from './core/rfb.js';
 


### PR DESCRIPTION
Newer versions of Safari seem to obey crossorigin more strictly than other browsers, and request core/rfb.js from the notebook server without a session cookie.

Not sure if it makes more sense to edit this file vs create a new one somewhere so that it'll be easier to update noVNC later.