### PR TITLE
Start session from $HOME

### DIFF
--- a/jupyter_desktop/share/xstartup
+++ b/jupyter_desktop/share/xstartup
@@ -1,2 +1,3 @@
 #!/bin/sh
+cd "$HOME"
 exec /usr/bin/dbus-launch xfce4-session


### PR DESCRIPTION
Otherwise the user will find themselves in the noVNC directory when they open a terminal (or any other application that inherits the cwd from the session)