### PR TITLE
Fix permissions on ~/.cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get -y update \
 # apt-get may result in root-owned directories/files under $HOME
 RUN chown -R $NB_UID:$NB_GID $HOME
 
-USER $NB_USER
 ADD . /opt/install
+RUN fix-permissions /opt/install
+
+USER $NB_USER
 RUN cd /opt/install && \
    conda env update -n base --file environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get -y update \
    xfce4-settings \
    xorg \
    xubuntu-icon-theme
+# apt-get may result in root-owned directories/files under $HOME
+RUN chown -R $NB_UID:$NB_GID $HOME
 
 USER $NB_USER
 ADD . /opt/install


### PR DESCRIPTION
`apt-get install xorg` somehow results in a `/home/jovyan/.cache` directory being created and owned by `root`, maybe because `HOME` is set to `/home/jovyan`? This prevents the `jovyan` user running other programs such as Firefox:

```
$ podman build -t jupyter-desktop-server .
...

$ podman run --rm jupyter-desktop-server ls -la
total 40
drwxrwxr-x. 7 jovyan users 4096 Aug 16 17:04 .
drwxr-xr-x. 3 root   root  4096 Aug 16 17:04 ..
-rw-rw-r--. 1 jovyan users  220 Feb 25 12:03 .bash_logout
-rw-rw-r--. 1 jovyan users 3770 Jun 18 03:05 .bashrc
drwx------. 2 root   root  4096 Aug 16 17:02 .cache
drwxrwxr-x. 2 jovyan users 4096 Aug 16 17:04 .conda
drwsrws---. 3 jovyan users 4096 Jun 18 03:10 .config
drwsrws---. 2 jovyan users 4096 Jun 18 03:10 .jupyter
-rw-rw-r--. 1 jovyan users  807 Feb 25 12:03 .profile
drwsrwsr-x. 2 jovyan users 4096 Jun 18 03:05 work

```

Note `fix-permissions $HOME` only makes it group writeable, it doesn't fix the owner which is why I'm using `chown` instead.
```
drwxrwxr-x. 7 jovyan users 4096 Aug 16 17:08 .
drwxr-xr-x. 3 root   root  4096 Aug 16 17:08 ..
-rw-rw-r--. 1 jovyan users  220 Feb 25 12:03 .bash_logout
-rw-rw-r--. 1 jovyan users 3770 Jun 18 03:05 .bashrc
drwxrwx---. 3 root   users 4096 Aug 16 17:08 .cache
drwxrwxr-x. 2 jovyan users 4096 Aug 16 17:08 .conda
drwsrws---. 3 jovyan users 4096 Jun 18 03:10 .config
drwsrws---. 2 jovyan users 4096 Jun 18 03:10 .jupyter
-rw-rw-r--. 1 jovyan users  807 Feb 25 12:03 .profile
drwsrwsr-x. 2 jovyan users 4096 Jun 18 03:05 work
```