### PR TITLE
Use TurboVNC if installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-get -y update \
    xfce4-settings \
    xorg \
    xubuntu-icon-theme
+
+RUN wget 'https://sourceforge.net/projects/turbovnc/files/2.2.5/turbovnc_2.2.5_amd64.deb/download' -O turbovnc_2.2.5_amd64.deb && \
+   apt-get install ./turbovnc_2.2.5_amd64.deb && \
+   rm ./turbovnc_2.2.5_amd64.deb
+
 # apt-get may result in root-owned directories/files under $HOME
 RUN chown -R $NB_UID:$NB_GID $HOME
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ RUN apt-get -y update \
    xorg \
    xubuntu-icon-theme
 
+# Remove light-locker to prevent screen lock
 RUN wget 'https://sourceforge.net/projects/turbovnc/files/2.2.5/turbovnc_2.2.5_amd64.deb/download' -O turbovnc_2.2.5_amd64.deb && \
-   apt-get install ./turbovnc_2.2.5_amd64.deb && \
+   apt-get install -y -q ./turbovnc_2.2.5_amd64.deb && \
+   apt-get remove -y -q light-locker && \
    rm ./turbovnc_2.2.5_amd64.deb && \
    ln -s /opt/TurboVNC/bin/* /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get -y update \
 
 RUN wget 'https://sourceforge.net/projects/turbovnc/files/2.2.5/turbovnc_2.2.5_amd64.deb/download' -O turbovnc_2.2.5_amd64.deb && \
    apt-get install ./turbovnc_2.2.5_amd64.deb && \
-   rm ./turbovnc_2.2.5_amd64.deb
+   rm ./turbovnc_2.2.5_amd64.deb && \
+   ln -s /opt/TurboVNC/bin/* /usr/local/bin/
 
 # apt-get may result in root-owned directories/files under $HOME
 RUN chown -R $NB_UID:$NB_GID $HOME

--- a/README.md
+++ b/README.md
@@ -5,22 +5,16 @@ Run XFCE (or other desktop environments) on a JupyterHub.
 
 This is based on https://github.com/ryanlovett/nbnovnc and a fork of https://github.com/manics/jupyter-omeroanalysis-desktop
 
+If a `vncserver` executable is found in `PATH` it will be used, otherwise a bundled TightVNC server is run.
+You can use this to install vncserver with support for other features, for example the [`Dockerfile`](./Dockerfile) in this repository installs TurboVNC for improved OpenGL support.
 
-## Docker 
 
-To spin up such a notebook, please build and run the container like this.
+## Docker
+
+To spin up such a notebook first build the container:
 
 ```bash
 $ docker build -t $(whoami)/$(basename ${PWD}) .
-Sending build context to Docker daemon  36.76MB
-Step 1/5 : FROM jupyter/datascience-notebook:latest
-**snip**
-Successfully installed aiohttp-3.6.2 async-timeout-3.0.1 jupyter-desktop-server-0.1.2 jupyter-server-proxy-1.5.0 multidict-4.7.6 simpervisor-0.3 yarl-1.4.2
-Removing intermediate container ed906d6b1074
- ---> 826211e74ce1
-Successfully built 826211e74ce1
-Successfully tagged myname/jupyter-desktop-server:latest
-$ 
 ```
 
 Now you can ran the image:

--- a/jupyter_desktop/__init__.py
+++ b/jupyter_desktop/__init__.py
@@ -10,14 +10,28 @@ def setup_desktop():
     # This is only readable, writeable & searchable by our uid
     sockets_dir = tempfile.mkdtemp()
     sockets_path = os.path.join(sockets_dir, 'vnc-socket')
+    turbovnc = '/opt/TurboVNC/bin/vncserver'
 
-    vnc_command = ' '.join((shlex.quote(p) for p in [
-        os.path.join(HERE, 'share/tigervnc/bin/vncserver'),
+    if os.path.exists(turbovnc):
+        vnc_args = [
+            '/opt/TurboVNC/bin/vncserver',
+        ]
+        socket_args = []
+    else:
+        # Use bundled tigervnc
+        vnc_args = [
+            os.path.join(HERE, 'share/tigervnc/bin/vncserver'),
+            '-rfbunixpath', sockets_path,
+        ]
+        socket_args = [
+            '--unix-target', sockets_path
+        ]
+
+    vnc_command = ' '.join(shlex.quote(p) for p in (vnc_args + [
         '-verbose',
         '-xstartup', os.path.join(HERE, 'share/xstartup'),
         '-geometry', '1680x1050',
         '-SecurityTypes', 'None',
-        '-rfbunixpath', sockets_path,
         '-fg',
         ':1',
     ]))
@@ -27,7 +41,7 @@ def setup_desktop():
             '--web', os.path.join(HERE, 'share/web/noVNC-1.1.0'),
             '--heartbeat', '30',
             '5901',
-            '--unix-target', sockets_path,
+        ] + socket_args + [
             '--',
             '/bin/sh', '-c',
             f'cd {os.getcwd()} && {vnc_command}'

--- a/jupyter_desktop/__init__.py
+++ b/jupyter_desktop/__init__.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+from shutil import which
 import tempfile
 
 
@@ -10,11 +11,11 @@ def setup_desktop():
     # This is only readable, writeable & searchable by our uid
     sockets_dir = tempfile.mkdtemp()
     sockets_path = os.path.join(sockets_dir, 'vnc-socket')
-    turbovnc = '/opt/TurboVNC/bin/vncserver'
+    vncserver = which('vncserver')
 
-    if os.path.exists(turbovnc):
+    if vncserver:
         vnc_args = [
-            '/opt/TurboVNC/bin/vncserver',
+            vncserver,
         ]
         socket_args = []
     else:


### PR DESCRIPTION
The Dockerfile defaults to TurboVNC. The plugin uses turbovnc is it's found at `/opt/TurboVNC/bin/vncserver` otherwise the existing behaviour is kept.

Closes https://github.com/yuvipanda/jupyter-desktop-server/issues/24